### PR TITLE
Fix: refresh token 만료 시 로그인 페이지로 리다이렉트처리

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -22,6 +22,22 @@ export const publicApi = axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
+function redirectToLogin() {
+  if (typeof window === 'undefined') return
+
+  const current = `${window.location.pathname}${window.location.hash}`
+  if (current.includes('/login')) return
+
+  const isHashRouter = window.location.hash.startsWith('#/')
+
+  if (isHashRouter) {
+    window.location.hash = '#/login'
+    return
+  }
+
+  window.location.assign('/login')
+}
+
 function emitAuthEvent(
   type: 'auth:expired' | 'auth:logout' | 'auth:inactive',
   detail?: unknown
@@ -114,6 +130,7 @@ async function refreshAccessToken(): Promise<string | null> {
     if (import.meta.env.DEV) console.error('❌ 토큰 재발급 실패:', e)
     await tokenService.clearTokens()
     emitAuthEvent('auth:expired', { reason: 'refresh_failed' })
+    redirectToLogin()
     return null
   }
 }
@@ -177,18 +194,21 @@ function installResponseInterceptor(instance: AxiosInstance) {
         }
 
         emitAuthEvent('auth:expired', { reason: 'refresh_failed_401' })
+        redirectToLogin()
         return Promise.reject(error)
       }
 
       if (status === 401 && originalRequest?._retry && !isAuthEndpoint) {
         await tokenService.clearTokens()
         emitAuthEvent('auth:expired', { reason: 'final_401_after_retry', url })
+        redirectToLogin()
         return Promise.reject(error)
       }
 
       if (status === 401 && !tokenService.refresh && !isAuthEndpoint) {
         await tokenService.clearTokens()
         emitAuthEvent('auth:expired', { reason: 'no_refresh_token', url })
+        redirectToLogin()
         return Promise.reject(error)
       }
 


### PR DESCRIPTION
## Purpose 🎯
 refresh token 만료 시 로그인 페이지로 리다이렉트처리

## Changes 🛠️
-  refresh token 만료 시 로그인 페이지로 리다이렉트처리

## Screenshots 📷

## Checklist
- [x] CI 통과를 확인했습니다
- [x] 라벨을 추가했습니다
- [x] **⭐ 최종 머지 지침 확인:**
  - **Feature → Develop** 머지 시: **Squash and Merge**를 사용합니다.
  - **Squash and Merge** 시 커밋 메시지의 타이틀이 **커밋타입:** 형식으로 되어있는지 확인해주세요.
  - **Develop → Main** 릴리즈 시: **Create Merge Commit**를 사용합니다.

## 🔗 Additional Context
